### PR TITLE
Modify power cap values

### DIFF
--- a/mihawk.xml
+++ b/mihawk.xml
@@ -12044,7 +12044,7 @@
 	</attribute>
 	<attribute>
 		<id>OPEN_POWER_MIN_POWER_CAP_WATTS</id>
-		<default>1945</default>
+		<default>500</default>
 	</attribute>
 	<attribute>
 		<id>OPEN_POWER_N_BULK_POWER_LIMIT_WATTS</id>
@@ -12056,7 +12056,7 @@
 	</attribute>
 	<attribute>
 		<id>OPEN_POWER_N_PLUS_ONE_BULK_POWER_LIMIT_WATTS</id>
-		<default>2375</default>
+		<default>2500</default>
 	</attribute>
 	<attribute>
 		<id>OPEN_POWER_N_PLUS_ONE_MAX_MEM_POWER_WATTS</id>


### PR DESCRIPTION
Modify OPEN_POWER_MIN_POWER_CAP_WATTS from 1945 to 500 to follow witherspoon's design and change OPEN_POWER_N_PLUS_ONE_BULK_POWER_LIMIT_WATTS from 2375 to 2500 for reserving some tolerance

Signed-off-by: Joy Chu <joy_chu@wistron.com>